### PR TITLE
Fix submodule URL to use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "IecString"]
 	path = IecString
-	url = https://github.com/tmatijevich/IecString.git
+	url = ../IecString.git
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "IecString"]
 	path = IecString
-	url = ssh://git@ssh.github.com:443/tmatijevich/IecString.git
+	url = https://github.com/tmatijevich/IecString.git


### PR DESCRIPTION
The submodule was configured with an SSH URL which prevented git submodule update --init --recursive from working for users without SSH keys configured for UserLog repo. More accessible.